### PR TITLE
Make the "friendly_name" friendly

### DIFF
--- a/entur-card/entur-card.js
+++ b/entur-card/entur-card.js
@@ -94,7 +94,7 @@ class  EnTurCard extends HTMLElement {
       const line = state.attributes['route'];
       const delay = state.attributes['delay'];
       const icon = entityId.icon ? entityId.icon : state.attributes['icon'];
-      const name = entityId.name ? entityId.name : state.attributes['friendly_name'];
+      const name = entityId.name ? entityId.name : state.attributes['friendly_name'].match(/entur (.+?)(?= platform|$)/i)[1];
       const destination = entityId.destination ? entityId.destination : 'unavailable';
       const time = moment(state.attributes['due_at']).format('H:mm');
       const human = moment(state.attributes['due_at']).fromNow();


### PR DESCRIPTION
If no name is provided:
- removes Entur prefix in friendly_name
- removes "platform ####" postfix from friendly_name if a platform entity is provided.