### PR TITLE
Remove header element when name+clock is not shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "home-assistant-js-websocket": "^4.4.0",
         "lit-element": "^2.2.1",
         "lit-html": "^1.1.2",
-        "moment": "^2.24.0"
+        "moment": "^2.27.0"
     },
     "devDependencies": {
         "@babel/core": "^7.6.4",

--- a/src/entur-card.ts
+++ b/src/entur-card.ts
@@ -58,10 +58,10 @@ class EnTurCard extends LitElement {
       return this.showWarning(localize('common.show_warning'));
     }
 
-    return html`
-      <ha-card>
+    const header = (this._config.name || this._config.show_clock)
+      ? html`
         <div class="card-header entur-header">
-          ${undefined !== this._config.name
+          ${false !== this._config.name
             ? html`
               <div class="entur-name">${this._config.name}</div>
             ` : html``
@@ -72,7 +72,12 @@ class EnTurCard extends LitElement {
             ` : html``
           }
         </div>
+        `
+        : undefined
 
+    return html`
+      <ha-card>
+        ${header}
         ${this._config.entities.map((entity) => {
           const stateObj = this.hass.states[entity.entity];
 

--- a/src/entur-card.ts
+++ b/src/entur-card.ts
@@ -3,7 +3,7 @@
 import { LitElement, html, customElement, property, CSSResult, TemplateResult } from 'lit-element';
 import { HomeAssistant, LovelaceCardEditor, getLovelace, LovelaceCard } from 'custom-card-helpers';
 
-import moment from 'moment/src/moment';
+import moment from 'moment';
 import 'moment/src/locale/nb';
 import style from './style';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface EnturCardConfig extends LovelaceCardConfig {
   show_human: boolean;
   show_extra_departures: boolean;
   type: string;
-  name?: string;
+  name?: string | false;
   show_warning?: boolean;
   show_error?: boolean;
   entity?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitAny": false,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
Also allows setting `name: false` explicitly to not show the name. As the documentation has it as a required property with a default value it makes sense to explicitly set it to false imo.